### PR TITLE
Added const to operator< in data_packing

### DIFF
--- a/labs/memory_bound/data_packing/solution.h
+++ b/labs/memory_bound/data_packing/solution.h
@@ -14,7 +14,7 @@ struct S {
   double d;
   bool b;
 
-  bool operator<(const S &s) { return this->i < s.i; }
+  bool operator<(const S &s) const { return this->i < s.i; }
 };
 
 void init(std::array<S, N> &arr);


### PR DESCRIPTION
This change fixes a compile error on MacOS using the Apple supplied libc++
libraries.

The libc++ headers shipped on MacOS have the call operator of `std::less`
marked `const`. That means `S::operator<` in data_packing/solution.h
must also be marked const in order to use it with `std::sort`.

