### PR TITLE
Support pre-AVX2 machines

### DIFF
--- a/tools/labs.cmake
+++ b/tools/labs.cmake
@@ -18,7 +18,7 @@ endif()
 
 # Set compiler options
 if(NOT MSVC)
-  set(CMAKE_C_FLAGS "-O3 -ffast-math -march=core-avx2 ${CMAKE_C_FLAGS}")
+  set(CMAKE_C_FLAGS "-O3 -ffast-math -march=native ${CMAKE_C_FLAGS}")
 else()
   set(CMAKE_C_FLAGS "/O2 /fp:fast /arch:AVX2 ${CMAKE_C_FLAGS}")
 


### PR DESCRIPTION
This fixes issue #2.
For GCC/Clang compilers it is safe to leave -march=native since they will automatically determine the target arch.
But for MSVC I'm not sure since the default for x86 in MSVC is SSE2. For now, let's not touch it.