### PR TITLE
gitignore: Ignore CLion artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ CTestTestfile.cmake
 _deps
 __pycache__
 *.pyc
+.idea/
+cmake-build-debug/
 
 build_solution
 build_baseline


### PR DESCRIPTION
Created if opening labs in CLion as cmake projects