### PR TITLE
Use reserve() instead of resize() for the lookups vector.

### DIFF
--- a/labs/memory_bound/swmem_prefetch_1/bench.cpp
+++ b/labs/memory_bound/swmem_prefetch_1/bench.cpp
@@ -7,7 +7,7 @@ static void bench1(benchmark::State &state) {
   // Init benchmark data
   auto hash_map = std::make_unique<hash_map_t>(HASH_MAP_SIZE);
   std::vector<int> lookups;
-  lookups.resize(NUMBER_OF_LOOKUPS);
+  lookups.reserve(NUMBER_OF_LOOKUPS);
   init(hash_map.get(), lookups);
 
   // Run the benchmark

--- a/labs/memory_bound/swmem_prefetch_1/validate.cpp
+++ b/labs/memory_bound/swmem_prefetch_1/validate.cpp
@@ -28,7 +28,7 @@ int main() {
   // Init benchmark data
   auto hash_map = std::make_unique<hash_map_t>(HASH_MAP_SIZE);
   std::vector<int> lookups;
-  lookups.resize(NUMBER_OF_LOOKUPS);
+  lookups.reserve(NUMBER_OF_LOOKUPS);
   init(hash_map.get(), lookups);
 
   auto original_result = original_solution(hash_map.get(), lookups);


### PR DESCRIPTION
The resize() call inserts NUMBER_OF_LOOKUPS default-constructed elements and the init() function inserts another NUMBER_OF_LOOKUPS elements.