### PR TITLE
Windows, multiconfig generator: improve comparison

### DIFF
--- a/tools/check_speedup.py
+++ b/tools/check_speedup.py
@@ -62,10 +62,10 @@ def buildAndRunBench(iterNumber, variant, cmakeFlags):
     labAbsPath = labRootPath
     if not os.path.isabs(labAbsPath):
       labAbsPath = os.path.join(saveCWD, labRootPath)
-    callWrapper("cmake -G Ninja -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_BUILD_TYPE=Release " + cmakeFlags + " \"" + labAbsPath + "\"")
+    callWrapper("cmake -B . -G Ninja -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_BUILD_TYPE=Release " + cmakeFlags + " -S \"" + labAbsPath + "\"")
     callWrapper("cmake --build . --config Release --parallel 8")
     # this will save score in result.json file
-    callWrapper("cmake --build . --target benchmarkLab")
+    callWrapper("cmake --build . --config Release --target benchmarkLab")
   except:
     print(bcolors.FAIL + variant + ": iteration " + str(iterNumber) + " - Failed" + bcolors.ENDC)
     return False


### PR DESCRIPTION
I added some cmake options to suppress `DEBUG configuration` warning and to simplify comparisons under MSVC.
I hope someone will check workability under Linux: -B and -S options.