### PR TITLE
Replaced custom version of `max` with `std::max`

### DIFF
--- a/labs/core_bound/vectorization_1/solution.cpp
+++ b/labs/core_bound/vectorization_1/solution.cpp
@@ -1,4 +1,5 @@
 #include "solution.hpp"
+#include <algorithm>
 #include <cassert>
 #include <type_traits>
 
@@ -63,8 +64,8 @@ result_t compute_alignment(std::vector<sequence_t> const &sequences1,
             (sequence1[row - 1] == sequence2[col - 1] ? match : mismatch);
         // Determine best score from diagonal, vertical, or horizontal
         // direction.
-        best_cell_score = max(best_cell_score, last_vertical_gap);
-        best_cell_score = max(best_cell_score, horizontal_gap_column[row]);
+        best_cell_score = std::max(best_cell_score, last_vertical_gap);
+        best_cell_score = std::max(best_cell_score, horizontal_gap_column[row]);
         // Cache next diagonal value and store optimum in score_column.
         last_diagonal_score = score_column[row];
         score_column[row] = best_cell_score;
@@ -73,9 +74,9 @@ result_t compute_alignment(std::vector<sequence_t> const &sequences1,
         last_vertical_gap += gap_extension;
         horizontal_gap_column[row] += gap_extension;
         // Store optimum between gap open and gap extension.
-        last_vertical_gap = max(last_vertical_gap, best_cell_score);
+        last_vertical_gap = std::max(last_vertical_gap, best_cell_score);
         horizontal_gap_column[row] =
-            max(horizontal_gap_column[row], best_cell_score);
+            std::max(horizontal_gap_column[row], best_cell_score);
       }
     }
 

--- a/labs/core_bound/vectorization_1/solution.hpp
+++ b/labs/core_bound/vectorization_1/solution.hpp
@@ -12,10 +12,3 @@ using result_t = std::array<int16_t, sequence_count_v>;
 
 result_t compute_alignment(std::vector<sequence_t> const &, std::vector<sequence_t> const &);
 std::pair<std::vector<sequence_t>, std::vector<sequence_t>> init();
-
-// Clang-12 compiler generates branches for std::max, which are often mispredicted
-// in this benchmark. That's the reason we provide branchless version of max function.
-template <typename T>
-inline T max(T a, T b) {
-	return a - ((a-b) & (a-b)>>31);
-}


### PR DESCRIPTION
Clang 12 generates slower code for the custom implementation of `max`.
Clang 14 generates the same conditional move for both custom `max` and `std::max`.