### PR TITLE
get rid of "not" "and"

### DIFF
--- a/labs/misc/io_opt1/solution.cpp
+++ b/labs/misc/io_opt1/solution.cpp
@@ -5,7 +5,7 @@
 
 uint32_t solution(const char *file_name) {
   std::fstream file_stream{file_name};
-  if (not file_stream.is_open())
+  if (!file_stream.is_open())
     throw std::runtime_error{"The file could not be opened"};
 
   // Initial value has all bits set to 1

--- a/labs/misc/io_opt1/validate.cpp
+++ b/labs/misc/io_opt1/validate.cpp
@@ -7,7 +7,7 @@
 
 uint32_t original_solution(const char *file_name) {
   std::fstream file_stream{file_name};
-  if (not file_stream.is_open())
+  if (!file_stream.is_open())
     throw std::runtime_error{"The file could not be opened"};
   uint32_t crc = 0xff'ff'ff'ffu;
   char c;


### PR DESCRIPTION
 get rid of two keywords: "not" & "and"  to make msvc can compile io_opt lab and huge page lab by default as mentioned in #70 