### PR TITLE
Fix msvc runtime crash when validating `dep_chains-2` lab

### DIFF
--- a/labs/core_bound/dep_chains_2/validate.cpp
+++ b/labs/core_bound/dep_chains_2/validate.cpp
@@ -58,7 +58,7 @@ int main() {
 
   std::random_device r;
   std::mt19937_64 random_engine(r());
-  std::uniform_int_distribution<int> distrib(0, std::numeric_limits<uint32_t>::max());
+  std::uniform_int_distribution<uint32_t> distrib(0, std::numeric_limits<uint32_t>::max());
 
   auto seed = distrib(random_engine);
   randomParticleMotionOriginal(particlesCopy, seed);


### PR DESCRIPTION
Hi thanks for the new dep_chains lab !

When compiling the validation exe with msvc and run it, the msvc runtime will complain about `invalid min and max arguments for uniform_real`, comes from `random` header when init uniform distribution:

```
        void _Init(_Ty _Min0, _Ty _Max0) noexcept { // set internal state
            _STL_ASSERT(_Min0 <= _Max0 && (0 <= _Min0 || _Max0 <= _Min0 + (numeric_limits<_Ty>::max)()),
                "invalid min and max arguments for uniform_real");
            _Min = _Min0;
            _Max = _Max0;
        }
```

Looking closely, I found that the template arg for `std::uniform_int_distribution` may be wrong and thus the uint32_t's max exceeds int's limit, so MSVC decides to assert it.  Clang doesn't have this crash problem but I think it's a bug anyway. 
