### PR TITLE
Make restrict modifier a macro, so it works across msvc and clang

### DIFF
--- a/labs/memory_bound/mem_alignment_1/solution.cpp
+++ b/labs/memory_bound/mem_alignment_1/solution.cpp
@@ -40,9 +40,9 @@ void copyFromMatrix(const Matrix &from, Matrix &to, int N, int K) {
 }
 
 // A simple GEMM. Use only for small matrices (up to 100 x 100)
-void interchanged_matmul(float* __restrict__ A, 
-                         float* __restrict__ B,
-                         float* __restrict__ C, int N, int K) {
+void interchanged_matmul(float* RESTRICT A, 
+                         float* RESTRICT B,
+                         float* RESTRICT C, int N, int K) {
   for (int i = 0; i < N; ++i)
     for (int k = 0; k < N; ++k)
       for (int j = 0; j < N; ++j)
@@ -50,9 +50,9 @@ void interchanged_matmul(float* __restrict__ A,
 }
 
 // Here is a blocked version for larger matrix sizes (e.g. 512 x 512 and beyond).
-void blocked_matmul(float* __restrict__ A, 
-                    float* __restrict__ B,
-                    float* __restrict__ C, int N, int K) {
+void blocked_matmul(float* RESTRICT A, 
+                    float* RESTRICT B,
+                    float* RESTRICT C, int N, int K) {
   constexpr int blockSize = 64;
   for (int ii = 0; ii < N; ii += blockSize)
     for (int kk = 0; kk < N; kk += blockSize)

--- a/labs/memory_bound/mem_alignment_1/solution.h
+++ b/labs/memory_bound/mem_alignment_1/solution.h
@@ -9,6 +9,12 @@
   #define CACHELINE_SIZE 64
 #endif
 
+#if defined(_MSC_VER)
+  #define RESTRICT __restrict
+#else
+  #define RESTRICT __restrict__
+#endif
+
 template <typename T>
 class CacheLineAlignedAllocator {
 public:
@@ -41,9 +47,9 @@ int n_columns(int N);
 void initRandom(Matrix &matrix, int N, int K);
 void initZero(Matrix &matrix, int N, int K);
 void copyFromMatrix(const Matrix &from, Matrix &to, int N, int K);
-void interchanged_matmul(float* __restrict__ A, 
-                         float* __restrict__ B,
-                         float* __restrict__ C, int N, int K);
-void blocked_matmul     (float* __restrict__ A, 
-                         float* __restrict__ B,
-                         float* __restrict__ C, int N, int K);
+void interchanged_matmul(float* RESTRICT A, 
+                         float* RESTRICT B,
+                         float* RESTRICT C, int N, int K);
+void blocked_matmul     (float* RESTRICT A, 
+                         float* RESTRICT B,
+                         float* RESTRICT C, int N, int K);

--- a/labs/memory_bound/mem_alignment_1/validate.cpp
+++ b/labs/memory_bound/mem_alignment_1/validate.cpp
@@ -3,9 +3,9 @@
 #include <cmath>
 #include <iostream>
 
-static void original_matmul(float* __restrict__ A, 
-                            float* __restrict__ B,
-                            float* __restrict__ C, int N) {
+static void original_matmul(float* RESTRICT A, 
+                            float* RESTRICT B,
+                            float* RESTRICT C, int N) {
   for (int i = 0; i < N; ++i)
     for (int k = 0; k < N; ++k)
       for (int j = 0; j < N; ++j)


### PR DESCRIPTION
Hi thanks for the new lab.

As far as I know, the equivant `__restrict__` keyword in msvc is `__restrict`, so in order for it to be compiled fine by MSVC by default, I propose use a macro like this.

(But clang seems works with `__restrict` too, maybe I can change all the occurence to `__restrict` ?) 