### PR TITLE
fix: bench rename

### DIFF
--- a/labs/core_bound/vectorization_1/bench.cpp
+++ b/labs/core_bound/vectorization_1/bench.cpp
@@ -1,7 +1,7 @@
 #include "benchmark/benchmark.h"
 #include "solution.hpp"
 
-static void compute_alignment(benchmark::State &state) {
+static void bench_compute_alignment(benchmark::State &state) {
   auto [sequences1, sequences2] = init();
 
   for (auto _ : state) {
@@ -11,7 +11,7 @@ static void compute_alignment(benchmark::State &state) {
 }
 
 // Register the functions as a benchmark
-BENCHMARK(compute_alignment);
+BENCHMARK(bench_compute_alignment);
 
 // Run the benchmark
 BENCHMARK_MAIN();


### PR DESCRIPTION
```c++
No instance of overloaded function "benchmark::internal::make_unique" matches the argument list BENCHMARK(compute_alignment);
```