### PR TITLE
[Data Packing] Make sizeof(S) = 8 for Zen

### DIFF
--- a/labs/memory_bound/data_packing/solution.h
+++ b/labs/memory_bound/data_packing/solution.h
@@ -7,11 +7,11 @@ constexpr int maxRandom = 100;
 
 // FIXME: this data structure can be reduced in size
 struct S {
+  unsigned i : 7;
+  unsigned l : 14;
+  unsigned s : 7;
+  unsigned b : 1;
   float d;
-  unsigned long long l:16;
-  unsigned int i:8;
-  unsigned short s:7;
-  bool b:1;
 
   bool operator<(const S &s) const { return this->i < s.i; }
 };

--- a/labs/memory_bound/data_packing/solution.h
+++ b/labs/memory_bound/data_packing/solution.h
@@ -16,6 +16,8 @@ struct S {
   bool operator<(const S &s) const { return this->i < s.i; }
 };
 
+static_assert(sizeof(S) == 8, "Bit packing failed, performance improvement is not guaranteed");
+
 void init(std::vector<S> &arr);
 S create_entry(int first_value, int second_value);
 void solution(std::vector<S> &arr);


### PR DESCRIPTION
I noticed that the official solution fails to reach the set performance threshold on Zen3 because sizeof(S) = 24. I could not figure out a reason for this, but here is an alternative solution that does not have this problem.

Commits with tests: https://github.com/dendibakh/perf-ninja/commits/data_packing_struct_size/
Look for "sizeof(S)" in the output.