### PR TITLE
[CMake] Uplift minimal cmake version to 3.25

### DIFF
--- a/labs/bad_speculation/branches_to_cmov_1/CMakeLists.txt
+++ b/labs/bad_speculation/branches_to_cmov_1/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.25)
 
 project(lab)
 

--- a/labs/bad_speculation/conditional_store_1/CMakeLists.txt
+++ b/labs/bad_speculation/conditional_store_1/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.25)
 
 project(lab)
 

--- a/labs/bad_speculation/lookup_tables_1/CMakeLists.txt
+++ b/labs/bad_speculation/lookup_tables_1/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.25)
 
 project(lab)
 

--- a/labs/bad_speculation/virtual_call_mispredict/CMakeLists.txt
+++ b/labs/bad_speculation/virtual_call_mispredict/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.25)
 
 project(lab)
 

--- a/labs/core_bound/compiler_intrinsics_1/CMakeLists.txt
+++ b/labs/core_bound/compiler_intrinsics_1/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.25)
 
 project(lab)
 

--- a/labs/core_bound/compiler_intrinsics_2/CMakeLists.txt
+++ b/labs/core_bound/compiler_intrinsics_2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.25)
 
 project(lab)
 

--- a/labs/core_bound/compiler_intrinsics_3/CMakeLists.txt
+++ b/labs/core_bound/compiler_intrinsics_3/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.25)
 
 project(lab)
 

--- a/labs/core_bound/compiler_intrinsics_4/CMakeLists.txt
+++ b/labs/core_bound/compiler_intrinsics_4/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.25)
 
 project(lab)
 

--- a/labs/core_bound/dep_chains_1/CMakeLists.txt
+++ b/labs/core_bound/dep_chains_1/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.25)
 
 project(lab)
 

--- a/labs/core_bound/dep_chains_2/CMakeLists.txt
+++ b/labs/core_bound/dep_chains_2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.25)
 
 project(lab)
 

--- a/labs/core_bound/function_inlining_1/CMakeLists.txt
+++ b/labs/core_bound/function_inlining_1/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.25)
 
 project(lab)
 

--- a/labs/core_bound/vectorization_1/CMakeLists.txt
+++ b/labs/core_bound/vectorization_1/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.25)
 
 project(lab)
 

--- a/labs/core_bound/vectorization_2/CMakeLists.txt
+++ b/labs/core_bound/vectorization_2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.25)
 
 project(lab)
 

--- a/labs/memory_bound/data_packing/CMakeLists.txt
+++ b/labs/memory_bound/data_packing/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.25)
 
 project(lab)
 

--- a/labs/memory_bound/false_sharing_1/CMakeLists.txt
+++ b/labs/memory_bound/false_sharing_1/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.25)
 
 project(lab)
 

--- a/labs/memory_bound/huge_pages_1/CMakeLists.txt
+++ b/labs/memory_bound/huge_pages_1/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.25)
 
 project(lab)
 

--- a/labs/memory_bound/loop_interchange_1/CMakeLists.txt
+++ b/labs/memory_bound/loop_interchange_1/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.25)
 
 project(lab)
 

--- a/labs/memory_bound/loop_interchange_2/CMakeLists.txt
+++ b/labs/memory_bound/loop_interchange_2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.25)
 
 project(lab)
 

--- a/labs/memory_bound/loop_tiling_1/CMakeLists.txt
+++ b/labs/memory_bound/loop_tiling_1/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.25)
 
 project(lab)
 

--- a/labs/memory_bound/mem_alignment_1/CMakeLists.txt
+++ b/labs/memory_bound/mem_alignment_1/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.25)
 
 project(lab)
 

--- a/labs/memory_bound/mem_order_violation_1/CMakeLists.txt
+++ b/labs/memory_bound/mem_order_violation_1/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.25)
 
 project(lab)
 

--- a/labs/memory_bound/swmem_prefetch_1/CMakeLists.txt
+++ b/labs/memory_bound/swmem_prefetch_1/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.25)
 
 project(lab)
 

--- a/labs/misc/io_opt1/CMakeLists.txt
+++ b/labs/misc/io_opt1/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.25)
 
 project(lab)
 

--- a/labs/misc/lto/CMakeLists.txt
+++ b/labs/misc/lto/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.25)
 
 project(lab)
 

--- a/labs/misc/pgo/CMakeLists.txt
+++ b/labs/misc/pgo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.25)
 
 project(lab)
 

--- a/labs/misc/warmup/CMakeLists.txt
+++ b/labs/misc/warmup/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.25)
 
 project(lab)
 


### PR DESCRIPTION
Compatibility with CMake < 3.5 has been removed from CMake and compatibility with CMake < 3.10 will be removed from a future version of CMake.